### PR TITLE
Don't subtract from outpoint 

### DIFF
--- a/calculations.rb
+++ b/calculations.rb
@@ -9,7 +9,7 @@ def get_closest_aligned_time(target_time)
   nearest_frame_index_for_target_time * frame_duration
 end
 
-def generate_command_and_directives_for_segment(index, target_start, target_end)
+def generate_command_and_directives_for_segment(index, target_start, target_end, is_last)
   puts "--- segment #{index + 1} ---"
 
   start_time = get_closest_aligned_time(target_start)
@@ -51,7 +51,12 @@ def generate_command_and_directives_for_segment(index, target_start, target_end)
 
   # inpoint is inclusive and outpoint is exclusive. To avoid overlap, we subtract
   # the duration of one frame from the outpoint.
-  outpoint = inpoint + real_duration - frame_duration
+  # we don't have to subtract a frame if this is the last segment.
+  subtract = frame_duration
+  if is_last
+    subtract = 0
+  end
+  outpoint = inpoint + real_duration - subtract
 
   puts "inpoint: #{inpoint}, outpoint: #{outpoint}"
 

--- a/run.rb
+++ b/run.rb
@@ -3,7 +3,7 @@ require_relative "./calculations"
 
 # Feel free to change these constants for your own testing.
 SINE_WAVE_DURATION = 10.to_f
-SINE_FREQUENCY = 1000.to_f
+SINE_FREQUENCY = 10.to_f
 TARGET_SEGMENT_DURATION = 1.0.to_f
 SINE_WAVE_FILE_NAME = "sine-wave-#{SINE_WAVE_DURATION.to_i}-seconds.wav"
 
@@ -18,7 +18,8 @@ system("ffmpeg -hide_banner -loglevel error -nostats -y -f lavfi -i \"sine=frequ
 commands_and_directives = (SINE_WAVE_DURATION / TARGET_SEGMENT_DURATION).ceil.to_i.times.map do |i|
   start_time = (i * TARGET_SEGMENT_DURATION * 1000000).round.to_i
   end_time = [((i + 1) * TARGET_SEGMENT_DURATION * 1000000).round, SINE_WAVE_DURATION * 1000000].min.to_i
-  generate_command_and_directives_for_segment(i, start_time, end_time)
+  is_last = i == (SINE_WAVE_DURATION / TARGET_SEGMENT_DURATION).ceil.to_i - 1
+  generate_command_and_directives_for_segment(i, start_time, end_time, is_last)
 end
 
 all_directives = commands_and_directives.map { |cmd, directives| directives }.join("\n")


### PR DESCRIPTION
Two changes:

- If it's the last section, we don't need to avoid overlap. Therefore we also don't need to subtract (in the example the audio ended up being a bit too short)
- It's much easier to see the difference in waveform if the frequency is just 10 than 1000